### PR TITLE
Fix cross-make argument check

### DIFF
--- a/cross-make.sh
+++ b/cross-make.sh
@@ -9,7 +9,7 @@
 # Passwordless login to the target machine is required.
 
 #config_options="--without-gencgc --with-cheneygc"
-if [ $1 = -p ]
+if [ "$1" = -p ]
 then
   ssh_port_opt="-p $2"
   scp_port_opt="-P $2"


### PR DESCRIPTION
## Summary
- fix quoting of first argument in cross-make.sh

## Testing
- `bash -n cross-make.sh`
- `bash cross-make.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842e52b2b00832480d873cf4f71332a